### PR TITLE
Updated Player Movement

### DIFF
--- a/Assets/Scenes/Initial Level.unity
+++ b/Assets/Scenes/Initial Level.unity
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 11185426}
   - component: {fileID: 11185425}
   - component: {fileID: 11185424}
+  - component: {fileID: 11185428}
   m_Layer: 0
   m_Name: Road2
   m_TagString: Untagged
@@ -220,6 +221,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!65 &11185428
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11185423}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 10.000002, y: 2.220446e-16, z: 10.000002}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &76383252
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -403,7 +417,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: 320b1c2af77554f99a1658df4a6d3d5c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.055
+      value: 0.22
       objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: 320b1c2af77554f99a1658df4a6d3d5c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -574,6 +588,7 @@ GameObject:
   - component: {fileID: 522536628}
   - component: {fileID: 522536627}
   - component: {fileID: 522536626}
+  - component: {fileID: 522536630}
   m_Layer: 0
   m_Name: Road1
   m_TagString: Untagged
@@ -659,6 +674,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &522536630
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522536625}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 10, y: 2.220446e-16, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &538137416
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -991,6 +1019,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Adult Camera1
   m_TagString: MainCamera
@@ -1063,6 +1092,19 @@ Transform:
   m_Father: {fileID: 240032745}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 17.836, y: 183.034, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1f2fe4f253930b4b859b2f86d3c9741, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rotationSpeed: 0
 --- !u!1 &1021449236
 GameObject:
   m_ObjectHideFlags: 0
@@ -1075,6 +1117,7 @@ GameObject:
   - component: {fileID: 1021449239}
   - component: {fileID: 1021449238}
   - component: {fileID: 1021449237}
+  - component: {fileID: 1021449241}
   m_Layer: 0
   m_Name: Road2 (1)
   m_TagString: Untagged
@@ -1160,6 +1203,68 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 28
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!65 &1021449241
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1021449236}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 10, y: 2.220446e-16, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1029479312 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -927199367670048503, guid: 320b1c2af77554f99a1658df4a6d3d5c, type: 3}
+  m_PrefabInstance: {fileID: 240032744}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1029479313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029479312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3dd1e86ec22db16439907e13a362e568, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 20
+  turnSpeed: 70
+  isOnGround: 1
+--- !u!54 &1029479315
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029479312}
+  serializedVersion: 2
+  m_Mass: 50
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
+--- !u!65 &1029479316
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029479312}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.801142, z: 1}
+  m_Center: {x: 0, y: 0.86662984, z: 0}
 --- !u!1001 &1048059126
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1458,7 +1563,7 @@ GameObject:
   - component: {fileID: 1270005585}
   m_Layer: 0
   m_Name: Terrain
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 2147483647

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -5,7 +5,10 @@ using UnityEngine;
 public class PlayerController : MonoBehaviour
 {
     [SerializeField] float speed = 10.0f;
-    [SerializeField] float turnSpeed = 70.0f;
+    //[SerializeField] float turnSpeed = 70.0f;
+
+    public Vector2 turn;
+    public float sensitivity = 100f;
 
     private Rigidbody playerRB;
 
@@ -19,6 +22,9 @@ public class PlayerController : MonoBehaviour
     void Start()
     {
         playerRB = GetComponent<Rigidbody>();
+
+        //This locks the cursor in the center of the screen and hides the mouse
+        Cursor.lockState = CursorLockMode.Locked;
         
     }
 
@@ -29,10 +35,21 @@ public class PlayerController : MonoBehaviour
         forwardInput = Input.GetAxis("Vertical");
         transform.Translate(Vector3.forward * Time.deltaTime * speed * forwardInput);
 
-        transform.Rotate(Vector3.up, Time.deltaTime * turnSpeed * horizontalInput);
+
+        //transform.Rotate(Vector3.up, Time.deltaTime * turnSpeed * horizontalInput);
+        transform.Translate(Vector3.right * Time.deltaTime * speed * horizontalInput);
+
+        //This uses the input for the mouse in order for you to rotate the character
+        turn.x += Input.GetAxis("Mouse X") * sensitivity * Time.deltaTime;
+        turn.y += Input.GetAxis("Mouse Y") * sensitivity * Time.deltaTime;
+        transform.localRotation = Quaternion.Euler(-turn.y, turn.x, 0);
+
+
+        //This line of code lets the game know if the player is actually touching the ground, and if so it allows you to jump when pressing the space key
         if (Input.GetKeyDown(KeyCode.Space) && isOnGround)
             playerRB.AddForce(Vector3.up * jumpForce, ForceMode.Impulse);
 
+        //The If statements control when the player is either sprinting or not upon holding or or depressing the L Shift key
         if (Input.GetKey(KeyCode.LeftShift))
             speed = 25;
 
@@ -47,4 +64,6 @@ public class PlayerController : MonoBehaviour
             isOnGround = true;
         }
     }
+
+    
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Ground
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- The player now rotates with the mouse/cursor

- A & D are left and right(Strafe)

- Rotate now moves the player in any direction, and it is not good. Need to add limits to the boundaries. Noticed model focuses on camera rather than player object when selecting. Could be causing issues.

 - Need to clean up the jump while moving. When moving there is not enough force to make the player really jump. Maybe change from If isOnGround to "If moving at X speed apply X force on jump. Else if apply normal jump force" etc

- Player tends to fall through the world on spawn after adding camera rotation. Something with immediately tipping the body since it is not centered when starting the test(Cursor is at top of screen when clicking play. Player tips backward) So I adjusted the player height until we figure that out. Either way - World is thin - Needs thickening

****May want to comment out the cursor lock when working on the game. Tends to be rather annoying during testing